### PR TITLE
use resource count of generated .arches file to send the user back to…

### DIFF
--- a/arches/app/media/js/bulk-upload.js
+++ b/arches/app/media/js/bulk-upload.js
@@ -70,6 +70,7 @@ $( document ).ready(function() {
     
     var filepath = '';
     var archesFilepath = '';
+    var resCt = 0
     var formdata = new FormData();
     var xhr = null;
     var load_id = '';
@@ -257,7 +258,10 @@ $( document ).ready(function() {
                 data: setValPostData(test,filePath),
                 success: function(result) {
                     displayResults(result,test)
-                    if (!result.success) {passed = false} else {archesFilepath = result.filepath;};
+                    if (!result.success) {passed = false} else {
+                        archesFilepath = result.filepath;
+                        resCt = result.resource_count;
+                    };
                 }
             });
         }
@@ -269,9 +273,8 @@ $( document ).ready(function() {
                 $('#validation-msg').css("color","green");
                 $('#validation-msg').text("Validation complete. All tests passed.");
                 $('#import-msg').css("color","green");
-                $('#import-msg').text("Ready to load.");
+                $('#import-msg').text("Ready to load. Resource count: "+resCt);
                 formdata.append('archesfile', archesFilepath)
-                
             } else {
                 $('#validate-load-mask').hide();
                 $('#validation-msg').css("color","red");
@@ -295,7 +298,14 @@ $( document ).ready(function() {
     $('#load-data-button').click( function () {
         $('#import-msg').css("color","orange");
         $('#import-msg').text("Importing data... this may take a while.");
-        $('#full-load-mask').show();
+        if (resCt > 50) {
+            window.alert("With a high resource count (> 50) \
+this operation may time out, but, your resources will \
+still load. You'll now be redirected to the bulk upload home page where\
+you will be able to see your load recorded once it is finished.")
+            window.location.href = $("#bulk-url").attr("data-url");
+        }
+        $('#validate-load-mask').show();
         $.ajax({
             beforeSend: function(request) {
                 request.setRequestHeader("X-CSRFToken",csrftoken);

--- a/arches/app/views/bulk_upload.py
+++ b/arches/app/views/bulk_upload.py
@@ -19,6 +19,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 import os
 import json
 import time
+import unicodecsv
 from StringIO import StringIO
 from django import forms
 from django.conf import settings
@@ -120,6 +121,15 @@ def validate(request):
     if "Has attachments" in out.getvalue():
         result['hasfiles'] = True
 
+    if valtype == "write_arches_file":
+        resource_ids = []
+        with open(destpath, "rb") as f:
+            reader = unicodecsv.reader(f, delimiter="|")
+            reader.next()
+            for row in reader:
+                resource_ids.append(row[0])
+        resource_count = len(set(resource_ids))
+        result['resource_count'] = resource_count
     return HttpResponse(json.dumps(result), content_type="application/json")
     
 def upload_spreadsheet(request):


### PR DESCRIPTION
… bulk upload home for large uploads

This update comes from the fact that large bulk uploads appear to now work because the server times out, and the user doesn't get a response from the bulk upload manager page. However, the resources do load in the background successfully, it's just confusing.

I'm added a little bit of logic that gets the number of resources that _will_ be loaded, and then if it's over 50 an alert is generated when the user clicks the "load" button that gives a brief message and sends the user back to the main bulk upload page to wait/refresh until the latest load log is recorded and displayed.